### PR TITLE
Change package name, update Typescript version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "redux-dag-history",
+  "name": "@essex/redux-dag-history",
   "version": "1.6.0",
   "description": "",
   "main": "index.js",
@@ -36,7 +36,7 @@
     "nyc": "^10.0.0",
     "ts-node": "^1.3.0",
     "ts-npm-lint": "^0.1.0",
-    "typescript": "^2.1.4-insiders.20161206",
+    "typescript": "^2.1.4",
     "typescript-eslint-parser": "^1.0.0"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2022,9 +2022,9 @@ typescript-eslint-parser@^1.0.0:
     lodash.unescape "4.0.0"
     object-assign "^4.0.1"
 
-typescript@^2.1.4-insiders.20161206:
-  version "2.1.4-insiders.20161206"
-  resolved "http://essex-private-npm.westus.cloudapp.azure.com:4873/typescript/-/typescript-2.1.4-insiders.20161206.tgz#9f816358519f4f40d6d35d0220085e77afd979cb"
+typescript@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.1.4.tgz#b53b69fb841126acb1dd4b397d21daba87572251"
 
 uglify-js@^2.6:
   version "2.7.3"


### PR DESCRIPTION
We were on an insiders version of Typescript to get early access to Object rest/spread language features. Since 2.1 has been published, we can use a mainstream version now. 

Publishing the package under the `essex` npm scope.