### PR TITLE
Various Cleanup Stuff

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "classnames": "^2.2.5",
     "cpx": "^1.3.1",
     "css-loader": "^0.26.1",
-    "electron": "^1.4.15",
+    "electron": "^1.6.2",
     "enzyme": "^2.7.1",
     "filesaver.js": "^0.2.0",
     "html-webpack-plugin": "^2.28.0",

--- a/packages/dag-history-component/example/state/reducers/app/metadata.ts
+++ b/packages/dag-history-component/example/state/reducers/app/metadata.ts
@@ -1,7 +1,7 @@
 import * as Actions from '../../Actions';
 
 const DEFAULT_STATE = {
-  name: 'INIT',
+  name: 'Initial',
   historyIndex: 0,
   source: null,
 };

--- a/packages/dag-history-component/src/components/Bookmark/Bookmark.tsx
+++ b/packages/dag-history-component/src/components/Bookmark/Bookmark.tsx
@@ -12,6 +12,7 @@ export interface IBookmarkProps {
   onClick?: Function;
   onClickEdit?: Function;
   annotation: string;
+  commitPathLength: number;
   onDiscoveryTrailIndexClicked?: (index: number) => void;
 }
 
@@ -32,19 +33,20 @@ const Bookmark: React.StatelessComponent<IBookmarkProps> = (props) => {
     onDiscoveryTrailIndexClicked,
     numLeadInStates,
     annotation,
+    commitPathLength,
   } = props;
   const highlight = determineHighlight(props);
   const isDiscoveryTrailVisible = active && numLeadInStates > 0;
-    const discoveryTrail = isDiscoveryTrailVisible ? (
-      <DiscoveryTrail
-        fullWidth
-        depth={this.commitPathLength - 1}
-        highlight={highlight}
-        leadIn={numLeadInStates}
-        active={active}
-        onIndexClicked={idx => onDiscoveryTrailIndexClicked(idx)}
-      />
-    ) : null;
+  const discoveryTrail = isDiscoveryTrailVisible ? (
+    <DiscoveryTrail
+      fullWidth
+      depth={commitPathLength - 1}
+      highlight={highlight}
+      leadIn={numLeadInStates}
+      active={active}
+      onIndexClicked={idx => onDiscoveryTrailIndexClicked(idx)}
+    />
+  ) : null;
   return (
     <div
       className={`history-bookmark ${active ? 'selected' : ''}`}
@@ -54,13 +56,13 @@ const Bookmark: React.StatelessComponent<IBookmarkProps> = (props) => {
           <div
             className={classnames('bookmark-title', { active })}
             onClick={() => onClickEdit('title')}
-            >
+          >
             {name}
           </div>
           <div
             className="bookmark-annotation"
             onClick={() => onClickEdit('annotation')}
-            >
+          >
             {annotation}
           </div>
         </div>

--- a/packages/dag-history-component/src/components/Bookmark/EditBookmark.tsx
+++ b/packages/dag-history-component/src/components/Bookmark/EditBookmark.tsx
@@ -159,13 +159,13 @@ export default class EditBookmark extends React.Component<IEditBookmarkProps, IE
                 className="discovery-trail-intro-button"
                 style={{marginLeft: 5}}
                 tabIndex={3}
-                onClick={(e) => this.onLeadInSet(commitPathLength - selectedDepth)}
+                onClick={(e) => this.onLeadInSet(commitPathLength - selectedDepth - 1)}
               >
                 Set intro
               </button>
             </div>
             <DiscoveryTrail
-              depth={commitPathLength}
+              depth={commitPathLength - 1}
               highlight={selectedDepth}
               leadIn={numLeadInStates}
               active={active}

--- a/packages/dag-history-component/src/components/History/HistoryView/ChronologicalHistoryView.tsx
+++ b/packages/dag-history-component/src/components/History/HistoryView/ChronologicalHistoryView.tsx
@@ -42,7 +42,7 @@ const ChronologicalHistoryView: React.StatelessComponent<IChronologicalHistoryVi
       {...props}
       chronological
       branchTypeOverride={'current'}
-      commitPath={props.history.chronologicalStates}
+      commitPath={props.history.graph.get('chronologicalStates').toJS()}
     />
   </div>
 );

--- a/packages/dag-history-component/src/components/History/StoryboardingView/index.tsx
+++ b/packages/dag-history-component/src/components/History/StoryboardingView/index.tsx
@@ -55,14 +55,17 @@ const StoryboardingView: React.StatelessComponent<IStoryboardingViewProps & IBoo
     handleStepBackUnbounded,
   } = makeActions(selectedBookmark, selectedBookmarkDepth, history, bookmarks, onSelectBookmarkDepth);
 
-  const initialDepth = new Bookmark(bookmarks[0], new DagGraph(history.graph)).startingDepth();
+  const bookmark = new Bookmark(bookmarks[0], new DagGraph(history.graph));
+  const initialDepth = bookmark.startingDepth();
+  const stateId = bookmark.commitPath[bookmark.sanitizeDepth(initialDepth)];
+
   return (
     <div className="history-container">
       <BookmarkListContainer {...props} />
       <Transport
         onBack={handleStepBack}
         onForward={handleStepForward}
-        onPlay={() => onStartPlayback({ initialDepth })}
+        onPlay={() => onStartPlayback({ initialDepth, stateId })}
         onStop={onStopPlayback}
         onStepBack={handleStepBack}
         onStepForward={handleStepForward}

--- a/packages/dag-history-component/src/components/History/index.tsx
+++ b/packages/dag-history-component/src/components/History/index.tsx
@@ -98,12 +98,12 @@ export default class History extends React.Component<IHistoryProps, {}> {
 
   onSaveClicked() {
     const { history, controlBar: { onSaveHistory }, bookmarks } = this.props;
-    const { current, lastBranchId, lastStateId, graph } = history;
+    const { current, graph } = history;
     // Pass the plain history up to the client to save
     onSaveHistory({
       current,
-      lastBranchId,
-      lastStateId,
+      lastBranchId: graph.get('lastBranchId'),
+      lastStateId: graph.get('lastStateId'),
       bookmarks,
       graph: graph.toJS(),
     });

--- a/packages/dag-history-component/src/components/Transport/Transport.scss
+++ b/packages/dag-history-component/src/components/Transport/Transport.scss
@@ -3,4 +3,9 @@
   display: flex;
   flex-direction: row;
   justify-content: space-around;
+
+  /**
+   * Remove the blue focus-outline
+   */
+  outline: none;
 }

--- a/packages/dag-history-component/src/state/Configuration.ts
+++ b/packages/dag-history-component/src/state/Configuration.ts
@@ -4,7 +4,7 @@ import { IComponentConfiguration } from './interfaces';  // eslint-disable-line 
 export default class ComponentConfiguration<T>
   extends Configuration<T>
   implements IComponentConfiguration<T> {
-  constructor(rawConfig: IComponentConfiguration<T>) {
+  constructor(rawConfig: IComponentConfiguration<T> = {}) {
     super(rawConfig);
   }
 

--- a/packages/dag-history-component/src/state/actions/creators.ts
+++ b/packages/dag-history-component/src/state/actions/creators.ts
@@ -8,10 +8,10 @@ const { createAction } = ReduxActions;
 // Simple Action Creators
 const doSelectBookmarkDepth = createAction<BookmarkDepthSelection>(Types.SELECT_BOOKMARK_DEPTH);
 const doBookmarkDragDrop = createAction<void>(Types.BOOKMARK_DRAG_DROP);
+export const doStartPlayback = createAction<StartPlaybackPayload>(Types.START_PLAYBACK);
 export const selectMainView = createAction(Types.SELECT_MAIN_VIEW);
 export const selectHistoryType = createAction<string>(Types.SELECT_HISTORY_TYPE);
 export const toggleBranchContainer = createAction<void>(Types.TOGGLE_BRANCH_CONTAINER);
-export const startPlayback = createAction<StartPlaybackPayload>(Types.START_PLAYBACK);
 export const stopPlayback = createAction<void>(Types.STOP_PLAYBACK);
 export const bookmarkDragStart = createAction<BookmarkDragStartPayload>(Types.BOOKMARK_DRAG_START);
 export const bookmarkDragHover = createAction<BookmarkDragHoverPayload>(Types.BOOKMARK_DRAG_HOVER);
@@ -24,6 +24,13 @@ export const moveBookmark = createAction<MoveBookmarkPayload>(Types.MOVE_BOOKMAR
 export const pinState = createAction<StateId>(Types.PIN_STATE);
 
 // Composite Action Creators
+export function startPlayback(payload: StartPlaybackPayload) {
+  return (dispatch) => {
+    dispatch(DagHistoryActions.jumpToState(payload.stateId));
+    dispatch(doStartPlayback(payload));
+  };
+}
+
 export function bookmarkDragDrop(payload: BookmarkDragDropPayload) {
   return (dispatch) => {
     dispatch(doBookmarkDragDrop());
@@ -58,6 +65,7 @@ export const selectBookmark = (bookmarkIndex: number, state: StateId) => (
 
 export interface StartPlaybackPayload {
   initialDepth: number;
+  stateId: StateId;
 }
 
 export interface AddBookmarkPayload {

--- a/packages/dag-history-component/src/state/reducers/isHistoryAction.ts
+++ b/packages/dag-history-component/src/state/reducers/isHistoryAction.ts
@@ -1,0 +1,5 @@
+export default function isHistoryAction(action: ReduxActions.Action<any>) {
+  return action &&
+    action.type &&
+    action.type.startsWith('DAG_HISTORY_');
+}

--- a/packages/dag-history-component/src/state/reducers/playback.ts
+++ b/packages/dag-history-component/src/state/reducers/playback.ts
@@ -6,6 +6,7 @@ import {
   START_PLAYBACK,
   STOP_PLAYBACK,
 } from '../actions/types';
+import isHistoryAction from './isHistoryAction';
 
 export const INITIAL_STATE = {
   isPlayingBack: false,
@@ -33,10 +34,11 @@ export default function (config: IConfiguration<any>) {
         bookmark: bookmarkIndex === undefined ? state.bookmark : bookmarkIndex,
         depth,
       };
-    } else if (action.type.indexOf('DAG_HISTORY_') !== 0 && config.actionFilter(action.type)) {
+    } else if (!isHistoryAction(action) && config.actionFilter(action.type)) {
       // Insertable actions clear the pinned state
       result = {
         ...state,
+        isPlayingBack: false,
         bookmark: undefined,
         depth: undefined,
       };

--- a/packages/dag-history-component/src/state/reducers/views.ts
+++ b/packages/dag-history-component/src/state/reducers/views.ts
@@ -6,6 +6,7 @@ import {
   SELECT_HISTORY_TYPE,
   TOGGLE_BRANCH_CONTAINER,
 } from '../actions/types';
+import isHistoryAction from './isHistoryAction';
 
 export const INITIAL_STATE = {
   mainView: 'history',
@@ -35,7 +36,7 @@ export default function makeReducer<T>(config: IComponentConfiguration<T>) {
         ...state,
         branchContainerExpanded: !state.branchContainerExpanded,
       };
-    } else if (action.type.indexOf('DAG_HISTORY_') !== 0 && config.actionFilter(action.type)) {
+    } else if (!isHistoryAction(action) && config.actionFilter(action.type)) {
       // Insertable actions clear the pinned state
       result = {
         ...state,

--- a/packages/dag-history-component/src/util/Bookmark.ts
+++ b/packages/dag-history-component/src/util/Bookmark.ts
@@ -6,7 +6,7 @@ import DagGraph from '@essex/redux-dag-history/lib/DagGraph'; // eslint-disable-
 export default class Bookmark {
   /**
    * Constructs a bookmark
-   * @param bookmark - The bookmark item in the history graph
+   * @param bookmark - The bookmark item in state
    * @param graph - The source graph for the bookmark
    */
   constructor( // eslint-disable-line

--- a/packages/dag-history-component/test/components/History/index.spec.tsx
+++ b/packages/dag-history-component/test/components/History/index.spec.tsx
@@ -5,7 +5,7 @@ import { Provider } from 'react-redux';
 import * as Promise from 'bluebird';
 import * as dagHistory from '@essex/redux-dag-history/lib/DagHistory';
 import History from '../../../src/components/History';
-
+import Configuration from '../../../src/state/Configuration';
 import { createStore } from 'redux';
 
 // It's kind of cheap, but rendering the top-level component
@@ -13,7 +13,7 @@ import { createStore } from 'redux';
 describe('The History Component', () => {
   it('can be rendered in branched mode', () => {
     const store = createStore(() => ({}));
-    const history = dagHistory.createHistory({}, 'initialBranch', 'initialState');
+    const history = dagHistory.createHistory({}, new Configuration());
     const rendered = mount(
       <Provider store={store}>
         <History
@@ -38,7 +38,7 @@ describe('The History Component', () => {
 
   it('can be rendered in chronological mode', () => {
     const store = createStore(() => ({}));
-    const history = dagHistory.createHistory({}, 'initialBranch', 'initialState');
+    const history = dagHistory.createHistory({}, new Configuration());
     const rendered = mount(
       <Provider store={store}>
         <History
@@ -62,7 +62,7 @@ describe('The History Component', () => {
 
   xit('can be rendered in storyboarding mode', () => {
     const store = createStore(() => ({}));
-    const history = dagHistory.createHistory({}, 'initialBranch', 'initialState');
+    const history = dagHistory.createHistory({}, new Configuration());
     const rendered = mount(
       <Provider store={store}>
         <History
@@ -86,7 +86,7 @@ describe('The History Component', () => {
 
   xit('can be rendered in playback mode', () => {
     const store = createStore(() => ({}));
-    const history = dagHistory.createHistory({}, 'initialBranch', 'initialState');
+    const history = dagHistory.createHistory({}, new Configuration());
 
     const rendered = mount(
       <Provider store={store}>

--- a/packages/dag-history-component/test/state/reducers/playback.spec.ts
+++ b/packages/dag-history-component/test/state/reducers/playback.spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { default as makeReducer, INITIAL_STATE } from '../../../src/state/reducers/playback';
 
 import {
-  startPlayback,
+  doStartPlayback,
   stopPlayback,
 } from '../../../src/state/actions/creators';
 import * as types from '../../../src/state/actions/types';
@@ -21,7 +21,7 @@ describe('The Playback reducer', () => {
     let state;
     const reduce = makeReducer(defaultConfig);
     state = reduce(state, { type: 'derp' });
-    state = reduce(state, startPlayback({ initialDepth: 3 }));
+    state = reduce(state, doStartPlayback({ initialDepth: 3, stateId: '1' }));
     expect(state).to.deep.equal({
       isPlayingBack: true,
       bookmark: 0,
@@ -33,7 +33,7 @@ describe('The Playback reducer', () => {
     let state;
     const reduce = makeReducer(defaultConfig);
     state = reduce(state, { type: 'derp' });
-    state = reduce(state, startPlayback({ initialDepth: 3 }));
+    state = reduce(state, doStartPlayback({ initialDepth: 3, stateId: '1' }));
     state = reduce(state, stopPlayback());
     expect(state).to.deep.equal(INITIAL_STATE);
   });
@@ -42,7 +42,7 @@ describe('The Playback reducer', () => {
     let state;
     const reduce = makeReducer(defaultConfig);
     state = reduce(state, { type: 'derp' });
-    state = reduce(state, startPlayback({ initialDepth: 3 }));
+    state = reduce(state, doStartPlayback({ initialDepth: 3, stateId: '1' }));
 
     state = reduce(state, {
       type: types.SELECT_BOOKMARK_DEPTH,

--- a/packages/dag-history-component/wallaby.conf.js
+++ b/packages/dag-history-component/wallaby.conf.js
@@ -3,17 +3,17 @@ const wallabyWebpack = require('wallaby-webpack'); // eslint-disable-line import
 module.exports = function configureWallaby(wallaby) {
   const webpackPostprocessor = wallabyWebpack({
     resolve: {
-      extensions: ['', '.js', '.jsx'],
+      extensions: ['.js', '.jsx'],
       alias: {
         sinon: 'sinon/pkg/sinon',
       },
     },
     module: {
-      loaders: [
-          { test: /\.html$/, loader: 'file-loader?name=[name].[ext]' },
-          { test: /\.css$/, loader: 'style-loader!css-loader' },
-          { test: /\.json$/, loader: 'json-loader' },
-          { test: /\.s(a|c)ss$/, loader: 'style-loader!css-loader!sass-loader' },
+      rules: [
+          { test: /\.html$/, use: 'file-loader?name=[name].[ext]' },
+          { test: /\.css$/, use: 'style-loader!css-loader' },
+          { test: /\.json$/, use: 'json-loader' },
+          { test: /\.s(a|c)ss$/, use: 'style-loader!css-loader!sass-loader' },
       ],
     },
   });
@@ -37,6 +37,7 @@ module.exports = function configureWallaby(wallaby) {
     },
     env: {
       kind: 'electron',
+      runner: '../../node_modules/.bin/electron'
     },
   };
 };

--- a/packages/redux-dag-history/package.json
+++ b/packages/redux-dag-history/package.json
@@ -2,7 +2,7 @@
   "name": "@essex/redux-dag-history",
   "version": "3.0.1",
   "description": "",
-  "main": "index.js",
+  "main": "lib/index.js",
   "scripts": {
     "clean": "../../node_modules/.bin/rimraf lib",
     "build": "../../node_modules/.bin/tsc",

--- a/packages/redux-dag-history/src/ActionTypes.ts
+++ b/packages/redux-dag-history/src/ActionTypes.ts
@@ -59,9 +59,11 @@ export const RENAME_BRANCH = action('rename_branch');
 
 /**
  * Squashes the ancestors of the current state that do not support multiple branches.
- * e.g.    b                                b
- *     a <               will turn into  a <
- **        c -> d -> [e                     [e]
+ * e.g. squashing [e] will result in
+ *
+ *        b                                b
+ *     a <                   ==>        a <
+ *         c -> d -> [e]                   [e]
  */
 export const SQUASH = action('squash');
 

--- a/packages/redux-dag-history/src/Configuration.ts
+++ b/packages/redux-dag-history/src/Configuration.ts
@@ -11,7 +11,7 @@ export const SQUASH = 'DAG_HISTORY_SQUASH';
 const DEFAULT_ACTION_FILTER = () => true;
 
 export default class Configuration<T> implements IConfiguration<T> {
-    constructor(protected rawConfig: IConfiguration<T>) {
+    constructor(protected rawConfig: IConfiguration<T> = {}) {
     }
 
     public get stateEqualityPredicate() {

--- a/packages/redux-dag-history/src/DagGraph.ts
+++ b/packages/redux-dag-history/src/DagGraph.ts
@@ -172,7 +172,7 @@ export default class DagGraph<T> {
    * Get the last-generated branch id
    */
   public get lastBranchId(): StateId {
-    return this.graph.get('lastStateId');
+    return this.graph.get('lastBranchId');
   }
 
   /**

--- a/packages/redux-dag-history/src/DagGraph.ts
+++ b/packages/redux-dag-history/src/DagGraph.ts
@@ -1,14 +1,25 @@
 import {
-    Map as ImmutableMap,
-    List as ImmutableList,
-    fromJS as ImmutableFromJS,
+  Map as ImmutableMap,
+  List as ImmutableList,
+  fromJS as ImmutableFromJS,
 } from 'immutable';
-import { BranchId, StateId } from './interfaces';
+import {
+  BranchId,
+  StateId,
+  StateHash,
+} from './interfaces';
 
 const log = require('debug')('redux-dag-history:DagGraph');
 const treeify = require('treeify');
 
+/**
+ * A convenient wrapper around the ImmutableJS-based Dag-History data structure
+ */
 export default class DagGraph<T> {
+  /**
+   * Constructs a new instance
+   * @param graph The immutableJS instance
+   */
   constructor(public graph: ImmutableMap<any, any>) {
     if (!graph) {
       throw new Error('\'graph\' parameter must be defined');
@@ -18,6 +29,9 @@ export default class DagGraph<T> {
     }
   }
 
+  /**
+   * Print out the state graph in the console, for debug purposes
+   */
   public print(): string {
     const graph = this.graph.toJS();
     let root: any = null;
@@ -47,6 +61,7 @@ export default class DagGraph<T> {
 
     const tree = {
       current: graph.current,
+      chronologicalStates: graph.chronologicalStates,
       branches: graph.branches,
       // states: graph.states,
       dag: root,
@@ -55,22 +70,46 @@ export default class DagGraph<T> {
     return result;
   }
 
+  /**
+   * Gets the current state ID
+   */
   public get currentStateId(): StateId {
     return this.graph.getIn(['current', 'state']);
   }
 
+  /**
+   * Gets the start depth of the current branch
+   * (i.e. how many commits it took from the dag root to reach the start of the current branch)
+   * @param branch The BranchId to get the starting depth of
+   */
   public branchStartDepth(branch: BranchId): number {
     return this.stateDepth(this.firstOn(branch));
   }
 
+  /**
+   * Gets the ending depth of the current branch
+   * (i.e. how many commits it took from the dag root to reach the end of the current branch)
+   * @param branch The BranchId to get the starting depth of
+   */
   public branchEndDepth(branch: BranchId): number {
     return this.stateDepth(this.latestOn(branch));
   }
 
+  /**
+   * Gets the depth of a specific state
+   * (i.e. how many commits it took from the root to reach the state)
+   * @param branch The BranchId to get the starting depth of
+   */
   public stateDepth(commit: StateId): number {
     return this.commitPath(commit).length - 1;
   }
 
+  /**
+   * Gets the depth of a commit on a branch
+   * (i.e. how many commits it took from the root to reach the commit on the branch)
+   * @param branch The branch to qualify the commit
+   * @param commit The commit to get the depth of
+   */
   public depthIndexOf(branch: BranchId, commit: StateId): number {
     const commits = this.branchCommitPath(branch);
     let foundIndex = commits.indexOf(commit);
@@ -82,6 +121,9 @@ export default class DagGraph<T> {
     }
   }
 
+  /**
+   * Gets the maximum depth of the graph
+   */
   public get maxDepth(): number {
     const branches = this.branches;
     const branchDepths = branches.map(b => this.branchEndDepth(b));
@@ -94,105 +136,216 @@ export default class DagGraph<T> {
     return max;
   }
 
+  /**
+   * Mutate the current state id
+   * @param stateId The new state id
+   */
   public setCurrentStateId(stateId: StateId) {
     this.graph = this.graph.setIn(['current', 'state'], stateId);
+    this.logVisit(stateId);
     return this;
   }
 
+  /**
+   * Get the current branch id
+   */
   public get currentBranch(): BranchId {
     return this.graph.getIn(['current', 'branch']);
   }
 
+  /**
+   * Mutate the current branch id
+   * @param branchId The new branch id
+   */
   public setCurrentBranch(branchId: BranchId) {
     this.graph = this.graph.setIn(['current', 'branch'], branchId);
     return this;
   }
 
+  /**
+   * Gets the latest state id on a given branch
+   * @param branch The branch to search on
+   */
   public latestOn(branch: BranchId): StateId {
     return this.graph.getIn(['branches', `${branch}`, 'latest']);
   }
 
+  /**
+   * Gets the 'committed' state id on a given branch.
+   * Pushing new states bumps the committed state id. The 'committed' state is the most recently visited in a branch.
+   * @param branch The branch to search on
+   */
   public committedOn(branch: BranchId): StateId {
     return this.graph.getIn(['branches', `${branch}`, 'committed']);
   }
 
+  /**
+   * Updates the latest state on the branch
+   * @param branch The branch id
+   * @param commit The new latest commit on the branchd
+   */
   public setLatest(branch: BranchId, commit: StateId) {
     this.graph = this.graph.setIn(['branches', `${branch}`, 'latest'], commit);
     return this;
   }
 
+  /**
+   * Updates the committed state on the branch
+   * @param branch The branch id
+   * @param commit The committed state id
+   */
   public setCommitted(branch: BranchId, commit: StateId) {
     this.graph = this.graph.setIn(['branches', `${branch}`, 'committed'], commit);
     return this;
   }
 
+  /**
+   * Each state is mapped to a single branch. This updates the branch for a state.
+   * @param commit The state id
+   * @param branch The branch that is now associated with the state.
+   */
   public markStateForBranch(commit: StateId, branch: BranchId) {
     this.graph = this.graph.setIn(['states', `${commit}`, 'branch'], branch);
     return this;
   }
 
+  /**
+   * Sets the first state id of a branch
+   * @param branch The branch id
+   * @param commit The first state id on the branch
+   */
   public setFirst(branch: BranchId, commit: StateId) {
     this.graph = this.graph.setIn(['branches', `${branch}`, 'first'], commit);
     return this;
   }
 
+  /**
+   * Gets the first state id on a branch
+   * @param branch The branch to search on
+   */
   public firstOn(branch: BranchId): StateId {
     return this.graph.getIn(['branches', `${branch}`, 'first']);
   }
 
+  /**
+   * Update the name of a state
+   * @param commit The id of the state to rename
+   * @param name The new name of the state
+   */
   public renameState(commit: StateId, name: string) {
     this.graph = this.graph.setIn(['states', `${commit}`, 'name'], name);
     return this;
   }
 
+  /**
+   * Gets the name of a given state
+   * @param commit The state id to get the name of
+   */
   public stateName(commit: StateId) {
     return this.graph.getIn(['states', `${commit}`, 'name']);
   }
 
+  /**
+   * Gets the name of a branch
+   * @param branch The branch to get the name of
+   */
   public getBranchName(branch: BranchId): string {
     return this.graph.getIn(['branches', `${branch}`, 'name']);
   }
 
+  /**
+   * Sets the name of a branch
+   * @param branch The branch to set the name of
+   * @param name The new branch name
+   */
   public setBranchName(branch: BranchId, name: string) {
     this.graph = this.graph.setIn(['branches', `${branch}`, 'name'], name);
     return this;
   }
 
+  /**
+   * Retrieve the physical state of a state id
+   * @param commit The state id to get the physical state of
+   */
   public getState(commit: StateId): T {
     return this.graph.getIn(['states', `${commit}`, 'state']);
   }
 
+  /**
+   * Inserts a nem tstate
+   * @param commit The new state id
+   * @param parent The parent state id
+   * @param state The physical state
+   * @param name The name of the state
+   */
   public insertState(commit: StateId, parent: StateId, state: T, name: string) {
     log('Inserting new commit', commit);
-    const newState = ImmutableFromJS({
-      name,
-      parent,
-    }).set('state', state);
+    const newState = ImmutableFromJS({ name, parent }).set('state', state);
     if (this.graph.getIn(['states', `${commit}`])) {
       log('Commit %s is already present', this.getState(commit));
     }
+
     this.graph = this.graph.setIn(['states', `${commit}`], newState);
     return this;
   }
 
+  /**
+   * Logs a state visitation into the chronological state array
+   */
+  public logVisit(state: StateId) {
+    const chronologicalStates = this.graph.get('chronologicalStates') as ImmutableList<any>;
+    this.graph = this.graph.setIn(['chronologicalStates'], chronologicalStates.push(state));
+    return this;
+  }
+
+  /**
+   * Get child state ids of a given state id.
+   * @param commit The parent state id
+   */
   public childrenOf(commit: StateId): StateId[] {
     const states = this.graph.get('states');
 
     return states.toSeq()
-        .filter((state: ImmutableMap<any, any>) => state.get('parent') === commit)
-        .map((state: ImmutableMap<any, any>, key: string) => key)
-        .toList().toJS();
+      .filter((state: ImmutableMap<any, any>) => state.get('parent') === commit)
+      .map((state: ImmutableMap<any, any>, key: string) => key)
+      .toList().toJS();
   }
 
+  /**
+   * Gets the parent state id of a given state id
+   * @param commit The state id to get the parent state id of
+   */
   public parentOf(commit: StateId): StateId {
     return this.graph.getIn(['states', `${commit}`, 'parent']);
   }
 
+  /**
+   * Gets 'alternate parents' for a given state. As the graph is expanded,
+   * and if state equality is enabled, then we can determine optimal paths to a given state as
+   * it is re-discovered through alternative means.
+   *
+   * i.e. When this happens
+   *
+   * Original Visitiation
+   *
+   * a -> b -> c -> D // orginal path
+   *      \--> D'     // branched path
+   *
+   * And D and D' are considered logically equivalent, then the parent state of D remains
+   * 'c', but 'b' is added as an 'alternate parent'
+   *
+   * @param commit The state id to find "alternate parents" of
+   */
   public alternateParentsOf(commit: StateId): StateId[] {
     const result = this.graph.getIn(['states', `${commit}`, 'alternateParents']);
     return result ? result.toJS() : [];
   }
 
+  /**
+   * Gets the shallowest parent of a commit. Compares the graph-depth of the parent and
+   * alternate parents.
+   * @param commit The state id to search on
+   */
   public shallowestParentOf(commit: StateId): StateId {
     const allParents = [
       this.parentOf(commit),
@@ -211,11 +364,20 @@ export default class DagGraph<T> {
     return result;
   }
 
+  /**
+   * Replace the physical state of a stateId
+   * @param commit The state ID to replace
+   * @param state The new state
+   */
   public replaceState(commit: StateId, state: T) {
     this.graph = this.graph.setIn(['states', `${commit}`, 'state'], state);
     return this;
   }
 
+  /**
+   * Gets the state-id path of a state id
+   * @param commit The state id to get the commit path of
+   */
   public commitPath(commit: StateId): StateId[] {
     if (commit === undefined) {
       return [];
@@ -233,6 +395,10 @@ export default class DagGraph<T> {
     return path;
   }
 
+  /**
+   * Gets the shortest path of a state id, considering alternate parentage
+   * @param commit The state id to get the commit path of
+   */
   public shortestCommitPath(commit: StateId): StateId[] {
     if (commit === undefined) {
       return [];
@@ -249,6 +415,10 @@ export default class DagGraph<T> {
     return path;
   }
 
+  /**
+   * Gets a path of all state ids on a branch
+   * @param branch The branch to get the commit path on
+   */
   public branchCommitPath(branch: BranchId): StateId[] {
     if (branch === undefined) {
       return [];
@@ -259,10 +429,20 @@ export default class DagGraph<T> {
     return path.slice(path.indexOf(firstCommitOnBranch));
   }
 
+  /**
+   * Sets the parent state id of a child state
+   * @param commit The child state id
+   * @param parent The parent state id
+   */
   public setParent(commit: StateId, parent: StateId) {
     this.graph = this.graph.setIn(['states', `${commit}`, 'parent'], parent);
   }
 
+  /**
+   * Adds an alternate parent to a state id
+   * @param commit The state id
+   * @param parent The new alternate parent
+   */
   public setAlternateParent(commit: StateId, parent: StateId) {
     if (this.parentOf(commit) !== parent) {
       return;
@@ -277,15 +457,29 @@ export default class DagGraph<T> {
     }
   }
 
+  /**
+   * Gets the list of branch ids available
+   */
   public get branches(): BranchId[] {
     const branches = this.graph.get('branches');
     return Array.from(branches.keys()) as BranchId[];
   }
 
+  /**
+   * Gets the branch a state is associated with
+   * @param commit The state id
+   */
   public branchOf(commit: StateId): BranchId {
     return this.graph.getIn(['states', `${commit}`, 'branch']);
   }
 
+  /**
+   * Gets all of the branches that a given state id is ancestral for.
+   *
+   * i.e. search all children and aggregate branch ids
+   *
+   * @param commit The state id to search on
+   */
   public branchesOf(commit: StateId): BranchId[] {
     if (!commit) {
       throw new Error('commit must be defined');
@@ -307,10 +501,19 @@ export default class DagGraph<T> {
     }
   }
 
+  /**
+   * Remove a state from the graph
+   * @param commit The state to remove
+   */
   private remove(commit: StateId) {
+    // TODO: we should remove this from the branch list and other metadata as well.
+    // This will be how we keep the DAG pruned to a fixed size.
     this.graph = this.graph.deleteIn(['states', `${commit}`]);
   }
 
+  /**
+   * Squash a branch down to one commit
+   */
   public squashCurrentBranch() {
     const toSquash: StateId[] = [];
     const branch = this.branchOf(this.currentStateId);
@@ -333,5 +536,33 @@ export default class DagGraph<T> {
     }
 
     return this;
+  }
+
+  /**
+   * Search for a state by hash code
+   * @param hash The hash code to search for
+   */
+  public getStateForHash(hash: StateHash): StateId {
+    return this.graph.getIn(['stateHash', hash]);
+  }
+
+  /**
+   * Registers a state with a hash code. Existing hashes are removed
+   * @param hash The hash code to register.
+   */
+  public setHashForState(hash: StateHash, state: StateId): void {
+    const stateHashPath = ['states', state, 'hash'];
+    const existingHash = this.graph.getIn(stateHashPath);
+
+    // Remove the hash from the state description and the hash->state map
+    if (existingHash) {
+      this.graph = this.graph
+        .removeIn(stateHashPath)
+        .deleteIn(['stateHash', existingHash]);
+    }
+
+    this.graph = this.graph
+      .setIn(stateHashPath, hash)
+      .setIn(['stateHash', hash], state);
   }
 }

--- a/packages/redux-dag-history/src/DagGraph.ts
+++ b/packages/redux-dag-history/src/DagGraph.ts
@@ -154,6 +154,36 @@ export default class DagGraph<T> {
   }
 
   /**
+   * Get the last-generated state id
+   */
+  public get lastStateId(): StateId {
+    return this.graph.get('lastStateId');
+  }
+
+  /**
+   * Set the last-generated state id
+   */
+  public setLastStateId(value: StateId) {
+    this.graph = this.graph.set('lastStateId', value);
+    return this;
+  }
+
+  /**
+   * Get the last-generated branch id
+   */
+  public get lastBranchId(): StateId {
+    return this.graph.get('lastStateId');
+  }
+
+  /**
+   * Set the last-generated branch id
+   */
+  public setLastBranchId(value: BranchId) {
+    this.graph = this.graph.set('lastBranchId', value);
+    return this;
+  }
+
+  /**
    * Mutate the current branch id
    * @param branchId The new branch id
    */

--- a/packages/redux-dag-history/src/DagHistory/clear.ts
+++ b/packages/redux-dag-history/src/DagHistory/clear.ts
@@ -9,8 +9,8 @@ import createHistory from './createHistory';
 
 const log = require('debug')('redux-dag-history:DagHistory');
 
-export default function clear<T>(history: IDagHistory<T>): IDagHistory<T> {
+export default function clear<T>(history: IDagHistory<T>, config: IConfiguration<T>): IDagHistory<T> {
   log('clearing history');
   const { graph, current } = history;
-  return createHistory(current);
+  return createHistory(current, config);
 }

--- a/packages/redux-dag-history/src/DagHistory/createBranch.ts
+++ b/packages/redux-dag-history/src/DagHistory/createBranch.ts
@@ -19,7 +19,6 @@ export default function createBranch<T>(
   const reader = new DagGraph(graph);
 
   return {
-    ...history,
     current,
     graph: graph.withMutations((g) => {
       const reader = new DagGraph(graph);
@@ -27,11 +26,11 @@ export default function createBranch<T>(
       const newBranchId = nextId(lastBranchId);
       return reader
         .setCurrentBranch(newBranchId)
+        .setLastBranchId(newBranchId)
         .setBranchName(newBranchId, branchName)
         .setCommitted(newBranchId, reader.currentStateId)
         .setFirst(newBranchId, reader.currentStateId)
-        .setLatest(newBranchId, reader.currentStateId)
-        .setLastBranchId(newBranchId);
+        .setLatest(newBranchId, reader.currentStateId);
     }),
   };
 }

--- a/packages/redux-dag-history/src/DagHistory/createBranch.ts
+++ b/packages/redux-dag-history/src/DagHistory/createBranch.ts
@@ -15,21 +15,23 @@ export default function createBranch<T>(
   history: IDagHistory<T>
 ): IDagHistory<T> {
   log('creating branch %s', branchName);
-  const { graph, current, lastBranchId } = history;
+  const { graph, current } = history;
   const reader = new DagGraph(graph);
-  const newBranchId = nextId(lastBranchId);
 
   return {
     ...history,
     current,
-    lastBranchId: newBranchId,
     graph: graph.withMutations((g) => {
-      new DagGraph(g)
+      const reader = new DagGraph(graph);
+      const { lastBranchId } = reader;
+      const newBranchId = nextId(lastBranchId);
+      return reader
         .setCurrentBranch(newBranchId)
         .setBranchName(newBranchId, branchName)
         .setCommitted(newBranchId, reader.currentStateId)
         .setFirst(newBranchId, reader.currentStateId)
-        .setLatest(newBranchId, reader.currentStateId);
+        .setLatest(newBranchId, reader.currentStateId)
+        .setLastBranchId(newBranchId);
     }),
   };
 }

--- a/packages/redux-dag-history/src/DagHistory/createHistory.ts
+++ b/packages/redux-dag-history/src/DagHistory/createHistory.ts
@@ -2,32 +2,90 @@ import {
   IDagHistory,
   StateId,
   BranchId,
+  IConfiguration,
 } from '../interfaces';
 import load from './load';
+import nextId from '../nextId';
 
 const log = require('debug')('redux-dag-history:DagHistory');
 
 export default function createHistory<T>(
   initialState: T = {} as T,
-  initialBranchName: string = 'Initial',
-  initialStateName: string = 'Initial',
+  config: IConfiguration<T>,
 ): IDagHistory<T> {
   log('creating history');
-  const currentStateId: StateId = undefined;
-  const currentBranchId: BranchId = undefined;
+  const stateId: StateId = nextId();
+  const branchId: BranchId = nextId();
+  const {
+    initialStateName,
+    initialBranchName,
+  } = config;
+
+  // We may need to insert the initial hash into the state data, so construct it here
+  const initialStateData = {
+    state: initialState,
+    name: initialStateName,
+    branch: 1,
+  };
+
+  // If possible, hash the initial state
+  let stateHash = {};
+  if (config.stateKeyGenerator) {
+    const initialHash = config.stateKeyGenerator(initialState);
+    stateHash[initialHash] = stateId;
+    initialStateData['hash'] = initialHash;
+  }
+
   return load<T>({
     current: initialState,
-    lastStateId: 0,
-    lastBranchId: 0,
-    stateHash: new Map<StateId, any>(), // eslint-disable-line new-parens
-    chronologicalStates: [],
+    /**
+     * The last used state id
+     */
+    lastStateId: stateId,
+
+    /**
+     * The last used branch id
+     */
+    lastBranchId: branchId,
+
     graph: {
+      /**
+       * A map of hash-code strings to state IDs. If a has function is defined in
+       * the configuration file, then these will be inserted.
+       */
+      stateHash,
+
+      /**
+       * A chronological listing of visited states
+       */
+      chronologicalStates: [stateId],
+
+      /**
+       * The current state and branch
+       */
       current: {
-        state: currentStateId,
-        branch: currentBranchId,
+        state: stateId,
+        branch: branchId,
       },
-      branches: {},
-      states: {},
+
+      /**
+       * A map of branch-ids to branch data
+       */
+      branches: {
+        [branchId]: {
+          latest: stateId,
+          name: initialBranchName,
+          first: stateId,
+          committed: stateId,
+        },
+      },
+
+      /**
+       * A map of state-ids to state data
+       */
+      states: {
+        [stateId]: initialStateData,
+      },
     },
   });
 }

--- a/packages/redux-dag-history/src/DagHistory/createHistory.ts
+++ b/packages/redux-dag-history/src/DagHistory/createHistory.ts
@@ -38,17 +38,17 @@ export default function createHistory<T>(
 
   return load<T>({
     current: initialState,
-    /**
-     * The last used state id
-     */
-    lastStateId: stateId,
-
-    /**
-     * The last used branch id
-     */
-    lastBranchId: branchId,
-
     graph: {
+      /**
+       * The last used state id
+       */
+      lastStateId: stateId,
+
+      /**
+       * The last used branch id
+       */
+      lastBranchId: branchId,
+
       /**
        * A map of hash-code strings to state IDs. If a has function is defined in
        * the configuration file, then these will be inserted.

--- a/packages/redux-dag-history/src/DagHistory/getExistingState.ts
+++ b/packages/redux-dag-history/src/DagHistory/getExistingState.ts
@@ -19,8 +19,10 @@ export default function getExistingState<T>(
   config: IConfiguration<T>,
 ): StateId {
   if (config.stateKeyGenerator && config.stateEqualityPredicate) {
+    const dagGraph = new DagGraph(history.graph);
     const hash = config.stateKeyGenerator(newState);
-    const found = history.stateHash.get(hash);
+    const found = dagGraph.getStateForHash(hash);
+
     if (found) {
       const existingState = new DagGraph<T>(history.graph) // eslint-disable-line new-parens
         .getState(found);

--- a/packages/redux-dag-history/src/DagHistory/insert.ts
+++ b/packages/redux-dag-history/src/DagHistory/insert.ts
@@ -31,17 +31,14 @@ export default function insert<T>(
   const newStateName = config.actionName(state, newStateId);
   const cousins = reader.childrenOf(parentStateId);
   const isBranching = cousins.length > 0 || lastBranchId > currentBranchId || currentBranchId === undefined;
-  const newBranchId = isBranching ? nextId(lastBranchId) : lastBranchId;
 
   return {
-    ...history,
     current: state,
     graph: graph.withMutations((g) => {
       const dg = new DagGraph(g)
         .insertState(newStateId, parentStateId, state, newStateName)
         .setCurrentStateId(newStateId)
-        .setLastStateId(newStateId)
-        .setLastBranchId(newBranchId);
+        .setLastStateId(newStateId);
 
       // If the state has a hash code, register the state
       if (config.stateKeyGenerator) {
@@ -51,8 +48,10 @@ export default function insert<T>(
       }
 
       if (isBranching) {
+        const newBranchId = nextId(lastBranchId);
         const newBranch = config.branchName(currentBranchId, newBranchId, newStateName);
         dg.setCurrentBranch(newBranchId)
+          .setLastBranchId(newBranchId)
           .setBranchName(newBranchId, newBranch)
           .setLatest(newBranchId, newStateId)
           .setFirst(newBranchId, newStateId)

--- a/packages/redux-dag-history/src/DagHistory/jump.ts
+++ b/packages/redux-dag-history/src/DagHistory/jump.ts
@@ -49,10 +49,10 @@ export function jumpLog<T>(
   assignObj = {},
   callback: ((g: DagGraph<T>) => void
 ) = () => ({})): IDagHistory<T> {
-  const { graph, chronologicalStates } = history;
+  const { graph } = history;
   const { currentStateId: alternateParent } = new DagGraph(graph);
 
-  const result = jump(
+  return jump(
     stateId,
     history,
     assignObj,
@@ -60,12 +60,4 @@ export function jumpLog<T>(
       writer.setAlternateParent(stateId, alternateParent);
       callback(writer);
     });
-
-  return {
-    ...result,
-    chronologicalStates: [
-      ...chronologicalStates,
-      stateId,
-    ],
-  };
 }

--- a/packages/redux-dag-history/src/DagHistory/jump.ts
+++ b/packages/redux-dag-history/src/DagHistory/jump.ts
@@ -22,15 +22,12 @@ const log = require('debug')('redux-dag-history:DagHistory');
 export function jump<T>(
   stateId: StateId,
   history: IDagHistory<T>,
-  assignObj = {},
   callback: ((g: DagGraph<T>) => void
 ) = () => ({})): IDagHistory<T> {
   const { graph } = history;
   const reader = new DagGraph(graph);
   const targetState = reader.getState(stateId);
   return {
-    ...history,
-    ...assignObj,
     current: unfreeze(targetState),
     graph: graph.withMutations((g) => {
       const writer = new DagGraph<T>(g) // eslint-disable-line new-parens
@@ -46,7 +43,6 @@ export function jump<T>(
 export function jumpLog<T>(
   stateId: StateId,
   history: IDagHistory<T>,
-  assignObj = {},
   callback: ((g: DagGraph<T>) => void
 ) = () => ({})): IDagHistory<T> {
   const { graph } = history;
@@ -55,7 +51,6 @@ export function jumpLog<T>(
   return jump(
     stateId,
     history,
-    assignObj,
     (writer) => {
       writer.setAlternateParent(stateId, alternateParent);
       callback(writer);

--- a/packages/redux-dag-history/src/DagHistory/jumpToBranch.ts
+++ b/packages/redux-dag-history/src/DagHistory/jumpToBranch.ts
@@ -19,7 +19,6 @@ export default function jumpToBranch<T>(branch: BranchId, history: IDagHistory<T
     jump(
       state,
       history,
-      {},
       writer => writer.setCurrentBranch(branch),
     )
   );

--- a/packages/redux-dag-history/src/DagHistory/jumpToLatestOnBranch.ts
+++ b/packages/redux-dag-history/src/DagHistory/jumpToLatestOnBranch.ts
@@ -22,7 +22,6 @@ export default function jumpToLatestOnBranch<T>(
     jump(
       state,
       history,
-      {},
       writer => writer.setCurrentBranch(branch),
     )
   );

--- a/packages/redux-dag-history/src/DagHistory/jumpToState.ts
+++ b/packages/redux-dag-history/src/DagHistory/jumpToState.ts
@@ -15,9 +15,8 @@ export default function jumpToState<T>(stateId: StateId, history: IDagHistory<T>
   const reader = new DagGraph(graph);
   const branches = reader.branchesOf(stateId);
   const branch = reader.currentBranch;
-  const updateObj: any = {};
 
-  return jump(stateId, history, updateObj, (writer) => {
+  return jump(stateId, history, (writer) => {
     if (branches.indexOf(branch) === -1) {
       const stateBranch = reader.branchOf(stateId);
       log('current branch %s is not present on commit %s, available are [%s] - setting current branch to %s', branch, stateId, branches.join(', '), stateBranch);

--- a/packages/redux-dag-history/src/DagHistory/jumpToStateLogged.ts
+++ b/packages/redux-dag-history/src/DagHistory/jumpToStateLogged.ts
@@ -18,9 +18,8 @@ export default function jumpToStateLogged<T>(
   const reader = new DagGraph(graph);
   const branches = reader.branchesOf(stateId);
   const branch = reader.currentBranch;
-  const updateObj: any = {};
 
-  return jumpLog(stateId, history, updateObj, (writer) => {
+  return jumpLog(stateId, history, (writer) => {
     if (branches.indexOf(branch) === -1) {
       const stateBranch = reader.branchOf(stateId);
       log('current branch %s is not present on commit %s, available are [%s] - setting current branch to %s', branch, stateId, branches.join(', '), stateBranch);

--- a/packages/redux-dag-history/src/DagHistory/renameState.ts
+++ b/packages/redux-dag-history/src/DagHistory/renameState.ts
@@ -17,7 +17,6 @@ export default function renameState<T>(
   log('rename state %s => %s', stateId, name);
   const { graph } = history;
   return {
-    ...history,
     current: history.current,
     graph: graph.withMutations(g => new DagGraph(g).renameState(stateId, name)),
   };

--- a/packages/redux-dag-history/src/DagHistory/replaceCurrentState.ts
+++ b/packages/redux-dag-history/src/DagHistory/replaceCurrentState.ts
@@ -20,7 +20,6 @@ export default function replaceCurrentState<T>(
   const currentStateId = reader.currentStateId;
 
   return {
-    ...history,
     current: state,
     graph: graph.withMutations(g => {
       const graph = new DagGraph(g);

--- a/packages/redux-dag-history/src/DagHistory/squash.ts
+++ b/packages/redux-dag-history/src/DagHistory/squash.ts
@@ -13,7 +13,6 @@ export default function squash<T>(history: IDagHistory<T>): IDagHistory<T> {
   log('squashing history');
   const { graph, current } = history;
   return {
-    ...history,
     current,
     graph: graph.withMutations(g => new DagGraph(g).squashCurrentBranch()),
   };

--- a/packages/redux-dag-history/src/interfaces.ts
+++ b/packages/redux-dag-history/src/interfaces.ts
@@ -65,53 +65,12 @@ export interface IDagHistory<T> {
    * The current application state
    */
   current: T;
-  lastStateId: StateId;
-  lastBranchId: BranchId;
 
   /**
-   * The explored state space, represented as a graph (future and past)
+   * The explored state space, represented as a graph (future and past).
+   * See DagGraph.ts and createHistory.ts for more details on the structure of this
    */
-  graph: ImmutableMap<any, any>; // {
-    /*
-      stateHash: Map<StateHash, StateId>;
-
-      // A chronological log of states visited in the application
-      chronologicalStates: StateId[];
-      current: {
-          state: StateId,
-
-          /**
-           * The current branch being used
-          branch: BranchId,
-      },
-
-      /**
-       * Branches are Pointers to State Tracks
-      branches: {
-          [id: string]: { // BranchId
-              latest: StateId;
-              committed: StateId;
-          };
-      };
-
-      /**
-       * A hash of states by ID
-      states: {
-          [id: string]: { // StateId
-              /**
-               * The application state for this state node
-              state: any;
-
-              /**
-               * The child states of this state
-              children: StateId[];
-
-              /**
-               * The parent state ID. If this is null, then this state has no parent.
-              parent?: StateId;
-          };
-      };
-  };*/
+  graph: ImmutableMap<any, any>;
 };
 
 export interface StateIdGenerator {

--- a/packages/redux-dag-history/src/interfaces.ts
+++ b/packages/redux-dag-history/src/interfaces.ts
@@ -37,9 +37,9 @@ export interface IConfiguration<T> {
   jumpToBranchActionType?: string;
   jumpToLatestOnBranchActionType?: string;
   createBranchActionType?: string;
+  squashActionType?: string;
   renameBranchActionType?: string;
   renameStateActionType?: string;
-  squashActionType?: string;
   initialBranchName?: string;
   initialStateName?: string;
   skipToStartActionType?: string;
@@ -69,22 +69,15 @@ export interface IDagHistory<T> {
   lastBranchId: BranchId;
 
   /**
-   * A weak mapping of hash-codes to state, for efficient duplicate state lookup
-   */
-  stateHash: Map<StateHash, StateId>;
-
-  /**
-   * A chronological log of states visited in the application
-   */
-  chronologicalStates: StateId[];
-
-  /**
    * The explored state space, represented as a graph (future and past)
    */
   graph: ImmutableMap<any, any>; // {
-      /*
-      current: {
+    /*
+      stateHash: Map<StateHash, StateId>;
 
+      // A chronological log of states visited in the application
+      chronologicalStates: StateId[];
+      current: {
           state: StateId,
 
           /**

--- a/packages/redux-dag-history/src/nextId.ts
+++ b/packages/redux-dag-history/src/nextId.ts
@@ -1,3 +1,4 @@
-export default function nextId(id: string) {
-  return `${parseInt(id, 10) + 1}`;
+export default function nextId(id?: string) {
+  const isDefined = id !== undefined;
+  return isDefined ? `${parseInt(id, 10) + 1}` : '1';
 }

--- a/packages/redux-dag-history/src/reducer.ts
+++ b/packages/redux-dag-history/src/reducer.ts
@@ -45,7 +45,7 @@ export default function trackHistory<T>(reducer: Function, rawConfig = {}) {
         break;
 
       case config.clearActionType:
-        history = DagHistory.clear(history);
+        history = DagHistory.clear(history, config);
         break;
 
       case config.undoActionType:
@@ -72,12 +72,12 @@ export default function trackHistory<T>(reducer: Function, rawConfig = {}) {
         history = DagHistory.createBranch(action.payload, history);
         break;
 
+      case config.squashActionType:
+         history = DagHistory.squash(history);
+         break;
+
       case config.renameBranchActionType:
         history = DagHistory.renameBranch(action.payload.branch, action.payload.name, history);
-        break;
-
-      case config.squashActionType:
-        history = DagHistory.squash(history);
         break;
 
       case config.renameStateActionType:
@@ -105,7 +105,7 @@ export default function trackHistory<T>(reducer: Function, rawConfig = {}) {
   function handleBlankState(action: Action<any>) {
     // State is either blank or a non-history object
     const state = reducer(undefined, action);
-    const result = DagHistory.createHistory(state, config.initialBranchName, config.initialStateName);
+    const result = DagHistory.createHistory(state, config);
     log('creating new history with initial state', state, result);
     return result;
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2015,7 +2015,7 @@ debug@0.7.4:
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-0.7.4.tgz#06e1ea8082c2cb14e39806e22e2f6f757f92af39"
 
-debug@^2.1.1, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3:
+debug@^2.1.1, debug@^2.1.3, debug@^2.2.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.1.tgz#79855090ba2c4e3115cc7d8769491d58f0491351"
   dependencies:
@@ -2227,9 +2227,9 @@ electron-to-chromium@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.2.2.tgz#e41bc9488c88e3cfa1e94bde28e8420d7d47c47c"
 
-electron@^1.4.15:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-1.6.0.tgz#d1d12024fe4e8d14128eb9c73b8a5253324ced06"
+electron@^1.6.2:
+  version "1.6.2"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-1.6.2.tgz#b0ccd7703f86d09c4d2a7273455c3f993f158994"
   dependencies:
     electron-download "^3.0.1"
     extract-zip "^1.0.3"
@@ -3786,16 +3786,6 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-linklocal@^2.8.0:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/linklocal/-/linklocal-2.8.0.tgz#77b97af16fff13da34dbb9fd3b53784c3d5baceb"
-  dependencies:
-    commander "^2.9.0"
-    debug "^2.3.3"
-    map-limit "0.0.1"
-    mkdirp "^0.5.1"
-    rimraf "^2.5.4"
-
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
@@ -4046,12 +4036,6 @@ mantra-core@^1.7.0:
     babel-runtime "6.x.x"
     react-komposer "^1.9.0"
     react-simple-di "^1.2.0"
-
-map-limit@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/map-limit/-/map-limit-0.0.1.tgz#eb7961031c0f0e8d001bf2d56fab685d58822f38"
-  dependencies:
-    once "~1.3.0"
 
 map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
@@ -4570,7 +4554,7 @@ once@^1.3.0, once@^1.4.0:
   dependencies:
     wrappy "1"
 
-once@~1.3.0, once@~1.3.3:
+once@~1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/once/-/once-1.3.3.tgz#b2e261557ce4c314ec8304f3fa82663e4297ca20"
   dependencies:


### PR DESCRIPTION
* Add more detailed comments to `createHistory.ts` and `DagGraph.ts`, which should communicate some of the key concepts better.
* Slightly restructure the DagHistory so that all the history metadata is embedded in the ImmutableJS instance, managed by `DagGraph.ts`. In the redux model, only the current state and the Immutable graph will exist at the top level.
* Restore the initial state concept. When a history is created, insert the initial state into the hash (if hashable).