### PR TITLE
Remove Component Statefulness, Refactor the DagGraph Layout

### DIFF
--- a/packages/dag-history-component/src/components/Bookmark/Bookmark.tsx
+++ b/packages/dag-history-component/src/components/Bookmark/Bookmark.tsx
@@ -7,6 +7,7 @@ const { PropTypes } = React;
 
 export interface IBookmarkProps {
   name: string;
+  index: number;
   active?: boolean;
   numLeadInStates?: number;
   onClick?: Function;
@@ -27,6 +28,7 @@ const determineHighlight = (props) => {
 const Bookmark: React.StatelessComponent<IBookmarkProps> = (props) => {
   const {
     name,
+    index,
     active,
     onClick,
     onClickEdit,
@@ -55,13 +57,13 @@ const Bookmark: React.StatelessComponent<IBookmarkProps> = (props) => {
         <div className="bookmark-details" onClick={onClick ? () => onClick() : undefined}>
           <div
             className={classnames('bookmark-title', { active })}
-            onClick={() => onClickEdit('title')}
+            onClick={() => onClickEdit(index)}
           >
             {name}
           </div>
           <div
             className="bookmark-annotation"
-            onClick={() => onClickEdit('annotation')}
+            onClick={() => onClickEdit(index)}
           >
             {annotation}
           </div>

--- a/packages/dag-history-component/src/components/Bookmark/EditBookmark.tsx
+++ b/packages/dag-history-component/src/components/Bookmark/EditBookmark.tsx
@@ -17,7 +17,6 @@ export interface IEditBookmarkProps {
   active?: boolean;
   onClick?: Function;
   onBookmarkChange?: Function;
-  focusOn?: string;
   onDoneEditing?: Function;
   shortestCommitPath?: StateId[];
   selectedDepth: number;

--- a/packages/dag-history-component/src/components/Bookmark/EditableBookmark.tsx
+++ b/packages/dag-history-component/src/components/Bookmark/EditableBookmark.tsx
@@ -3,7 +3,7 @@ import * as classnames from 'classnames';
 import { StateId } from '@essex/redux-dag-history/lib/interfaces';
 import './Bookmark.scss';
 import EditBookmark from './EditBookmark';
-import {default as Bookmark, IBookmarkProps } from './Bookmark';
+import { default as Bookmark, IBookmarkProps } from './Bookmark';
 import DiscoveryTrail from '../DiscoveryTrail';
 const { PropTypes } = React;
 
@@ -11,70 +11,58 @@ export interface IEditableBookmarkProps extends IBookmarkProps {
   index: number;
   numLeadInStates?: number;
   onBookmarkChange?: Function;
+  onBookmarkEdit?: Function;
+  onBookmarkEditDone?: Function;
   shortestCommitPath?: StateId[];
   selectedDepth?: number;
   onSelectBookmarkDepth?: Function;
+  editMode: boolean;
 }
 
 export interface IEditableBookmarkState {
-  editMode: boolean;
-  focusOn?: string;
 }
 
-export default class EditableBookmark extends React.PureComponent<IEditableBookmarkProps, IEditableBookmarkState> {
-  public static propTypes = {
-    index: PropTypes.number,
-    name: PropTypes.string.isRequired,
-    annotation: PropTypes.string.isRequired,
-    numLeadInStates: PropTypes.number,
-    active: PropTypes.bool,
-    onClick: PropTypes.func,
-    onBookmarkChange: PropTypes.func,
-    onDiscoveryTrailIndexClicked: PropTypes.func,
-    shortestCommitPath: PropTypes.arrayOf(PropTypes.string),
-    selectedDepth: PropTypes.number,
-    onSelectBookmarkDepth: PropTypes.func,
-  };
+const EditableBookmark: React.StatelessComponent<IEditableBookmarkProps> = (props) => {
+  const {
+    editMode,
+    onBookmarkEdit,
+    onBookmarkEditDone,
+  } = props;
+  const innerBookmark = editMode ? (
+    <EditBookmark {...props} onDoneEditing={onBookmarkEditDone} />
+  ) : (
+    <Bookmark {...props} onClickEdit={onBookmarkEdit} />
+  );
 
-  public static defaultProps = {
-    shortestCommitPath: [],
-  };
+  return (
+    <div>
+      {innerBookmark}
+    </div>
+  );
+};
+EditableBookmark.propTypes = {
+  index: PropTypes.number,
+  name: PropTypes.string.isRequired,
+  annotation: PropTypes.string.isRequired,
+  numLeadInStates: PropTypes.number,
+  active: PropTypes.bool,
+  onClick: PropTypes.func,
+  onBookmarkChange: PropTypes.func,
+  onBookmarkEdit: PropTypes.func,
+  onBookmarkEditDone: PropTypes.func,
+  onDiscoveryTrailIndexClicked: PropTypes.func,
+  shortestCommitPath: PropTypes.arrayOf(PropTypes.string),
+  selectedDepth: PropTypes.number,
+  onSelectBookmarkDepth: PropTypes.func,
+  editMode: PropTypes.bool,
+};
+EditableBookmark.defaultProps = {
+  index: null,
+  editMode: false,
+  name: '',
+  annotation: '',
+  commitPathLength: 0,
+  shortestCommitPath: [],
+};
 
-  constructor() {
-    super();
-    this.state = { editMode: false };
-  }
-
-  onClickEdit(focusOn) {
-    this.setState({ editMode: true, focusOn });
-  }
-
-  onDoneEditing() {
-    this.setState({ editMode: false });
-  }
-
-  render() {
-    const {
-      editMode,
-      focusOn,
-    } = this.state;
-
-    const innerBookmark = editMode ? (
-      <EditBookmark
-        {...this.props}
-        focusOn={focusOn}
-        onDoneEditing={() => this.onDoneEditing()}
-      />
-    ) : (
-      <Bookmark
-        {...this.props}
-        onClickEdit={t => this.onClickEdit(t)}
-      />
-    );
-    return (
-      <div>
-        {innerBookmark}
-      </div>
-    );
-  }
-}
+export default EditableBookmark;

--- a/packages/dag-history-component/src/components/Bookmark/index.tsx
+++ b/packages/dag-history-component/src/components/Bookmark/index.tsx
@@ -25,12 +25,12 @@ const dragSource = {
     return { index };
   },
   endDrag(props: IDragDropBookmarkProps, monitor, component) {
-    const { dispatch } = props;
+    const { dispatch, hoverIndex, dragIndex } = props;
     const item = monitor.getItem();
-    // TODO: use key instead for this?
+    const droppedOn = hoverIndex < dragIndex ? hoverIndex : hoverIndex - 1;
     dispatch(bookmarkDragDrop({
       index: item.index,
-      droppedOn: props.hoverIndex,
+      droppedOn,
     }));
   },
 };

--- a/packages/dag-history-component/src/components/BookmarkList/index.tsx
+++ b/packages/dag-history-component/src/components/BookmarkList/index.tsx
@@ -12,6 +12,9 @@ export interface IBookmarkListProps {
   onBookmarkClick?: Function;
   onSelectState?: Function;
   onSelectBookmarkDepth?: Function;
+  bookmarkEditIndex: number;
+  onBookmarkEdit: Function;
+  onBookmarkEditDone: Function;
 
   dragIndex?: number;
   hoverIndex?: number;
@@ -43,16 +46,22 @@ export default class BookmarkList extends React.PureComponent<IBookmarkListProps
       dragIndex,
       hoverIndex,
       dragKey,
+      onBookmarkEdit,
+      onBookmarkEditDone,
+      bookmarkEditIndex,
     } = this.props;
 
     let bookmarkViews = bookmarks.map((s, index) => (
       <Bookmark
         {...s}
+        editMode={index === bookmarkEditIndex}
         hoverIndex={hoverIndex}
         dragIndex={dragIndex}
         dragKey={dragKey}
         key={`bookmark::${s.stateId}`}
         index={index}
+        onBookmarkEdit={onBookmarkEdit}
+        onBookmarkEditDone={onBookmarkEditDone}
         stateId={s.stateId}
         onSelectBookmarkDepth={onSelectBookmarkDepth}
         onClick={() => this.onBookmarkClick(index, s.stateId)}

--- a/packages/dag-history-component/src/components/History/StoryboardingView/BookmarkListContainer.tsx
+++ b/packages/dag-history-component/src/components/History/StoryboardingView/BookmarkListContainer.tsx
@@ -14,6 +14,7 @@ export interface IBookmarkListContainerStateProps {
   dragIndex?: number;
   hoverIndex?: number;
   dragKey?: string;
+  bookmarkEditIndex?: number;
 }
 
 export interface IBookmarkListContainerDispatchProps {
@@ -21,6 +22,8 @@ export interface IBookmarkListContainerDispatchProps {
   onBookmarkChange: Function;
   onSelectState: Function;
   onSelectBookmarkDepth: Function;
+  onBookmarkEdit: Function;
+  onBookmarkEditDone: Function;
 }
 
 export interface IBookmarkListContainerOwnProps {
@@ -46,6 +49,9 @@ const BookmarkListContainer: React.StatelessComponent<IBookmarkListContainerProp
     onBookmarkChange,
     onSelectState,
     onSelectBookmarkDepth,
+    onBookmarkEdit,
+    onBookmarkEditDone,
+    bookmarkEditIndex,
     selectedBookmark: selectedBookmarkIndex,
     selectedBookmarkDepth: selectedBookmarkDepthIndex,
     dragIndex,
@@ -82,6 +88,9 @@ const BookmarkListContainer: React.StatelessComponent<IBookmarkListContainerProp
   });
   return (
     <BookmarkList
+      onBookmarkEdit={onBookmarkEdit}
+      onBookmarkEditDone={onBookmarkEditDone}
+      bookmarkEditIndex={bookmarkEditIndex}
       dragIndex={dragIndex}
       hoverIndex={hoverIndex}
       dragKey={dragKey}
@@ -103,6 +112,7 @@ BookmarkListContainer.propTypes = {
   dragIndex: React.PropTypes.number,
   hoverIndex: React.PropTypes.number,
   dragKey: React.PropTypes.string,
+  bookmarkEditIndex: React.PropTypes.number,
 };
 
 export default connect<IBookmarkListContainerStateProps, IBookmarkListContainerDispatchProps, IBookmarkListContainerOwnProps>(
@@ -112,5 +122,7 @@ export default connect<IBookmarkListContainerStateProps, IBookmarkListContainerD
     onBookmarkChange: Actions.changeBookmark,
     onSelectState: DagHistoryActions.jumpToState,
     onSelectBookmarkDepth: Actions.selectBookmarkDepth,
+    onBookmarkEdit: Actions.bookmarkEdit,
+    onBookmarkEditDone: Actions.bookmarkEditDone,
   }, dispatch)
 )(BookmarkListContainer);

--- a/packages/dag-history-component/src/components/History/StoryboardingView/index.tsx
+++ b/packages/dag-history-component/src/components/History/StoryboardingView/index.tsx
@@ -26,6 +26,7 @@ export interface IStoryboardingViewOwnProps {
   bookmarks: IBookmark[];
   dragIndex?: number;
   hoverIndex?: number;
+  bookmarkEditIndex?: number;
 }
 
 export interface IStoryboardingViewProps extends
@@ -45,6 +46,7 @@ const StoryboardingView: React.StatelessComponent<IStoryboardingViewProps & IBoo
     onSelectBookmarkDepth,
     dragIndex,
     hoverIndex,
+    bookmarkEditIndex,
   } = props;
 
   const {

--- a/packages/dag-history-component/src/components/History/index.tsx
+++ b/packages/dag-history-component/src/components/History/index.tsx
@@ -40,6 +40,7 @@ export default class History extends React.Component<IHistoryProps, {}> {
     dragIndex: PropTypes.number,
     dragKey: PropTypes.string,
     hoverIndex: PropTypes.number,
+    bookmarkEditIndex: PropTypes.number,
     isPlayingBack: PropTypes.bool,
 
     /**
@@ -128,11 +129,6 @@ export default class History extends React.Component<IHistoryProps, {}> {
     const doConfirm = onConfirmClear || (() => true);
     const confirmed = await doConfirm();
     return confirmed && onClear();
-  }
-
-  onUnderViewClicked(underView) {
-    log('underview clicked', underView);
-    this.setState({ ...this.state, underView });
   }
 
   renderPlayback() {

--- a/packages/dag-history-component/src/components/History/interfaces.ts
+++ b/packages/dag-history-component/src/components/History/interfaces.ts
@@ -8,6 +8,7 @@ export interface IHistoryContainerSharedProps {
   historyType: string;
   dragIndex?: number;
   hoverIndex?: number;
+  bookmarkEditIndex?: number;
   branchContainerExpanded?: boolean;
   selectedBookmark?: number;
   selectedBookmarkDepth?: number;

--- a/packages/dag-history-component/src/components/createHistoryContainer.tsx
+++ b/packages/dag-history-component/src/components/createHistoryContainer.tsx
@@ -80,6 +80,7 @@ export default function createHistoryContainer(getMiddlewareState: Function, get
       dragIndex: component.dragDrop.sourceIndex,
       dragKey: component.dragDrop.sourceKey,
       hoverIndex: component.dragDrop.hoverIndex,
+      bookmarkEditIndex: component.bookmarkEdit.editIndex,
       branchContainerExpanded: component.views.branchContainerExpanded,
       selectedBookmark: component.playback.bookmark,
       selectedBookmarkDepth: component.playback.depth,

--- a/packages/dag-history-component/src/state/actions/creators.ts
+++ b/packages/dag-history-component/src/state/actions/creators.ts
@@ -19,11 +19,20 @@ export const bookmarkDragCancel = createAction<void>(Types.BOOKMARK_DRAG_CANCEL)
 export const addBookmark = createAction<AddBookmarkPayload>(Types.ADD_BOOKMARK);
 export const removeBookmark = createAction<StateId>(Types.REMOVE_BOOKMARK);
 export const renameBookmark = createAction<RenameBookmarkPayload>(Types.RENAME_BOOKMARK);
-export const changeBookmark = createAction<ChangeBookmarkPayload>(Types.CHANGE_BOOKMARK);
+export const doChangeBookmark = createAction<ChangeBookmarkPayload>(Types.CHANGE_BOOKMARK);
 export const moveBookmark = createAction<MoveBookmarkPayload>(Types.MOVE_BOOKMARK);
 export const pinState = createAction<StateId>(Types.PIN_STATE);
+export const bookmarkEdit = createAction<number>(Types.BOOKMARK_EDIT);
+export const bookmarkEditDone = createAction(Types.BOOKMARK_EDIT_DONE);
 
 // Composite Action Creators
+export function changeBookmark(payload: ChangeBookmarkPayload) {
+  return (dispatch) => {
+    dispatch(doChangeBookmark(payload));
+    dispatch(bookmarkEditDone());
+  };
+}
+
 export function startPlayback(payload: StartPlaybackPayload) {
   return (dispatch) => {
     dispatch(DagHistoryActions.jumpToState(payload.stateId));

--- a/packages/dag-history-component/src/state/actions/types.ts
+++ b/packages/dag-history-component/src/state/actions/types.ts
@@ -11,6 +11,8 @@ export const BOOKMARK_DRAG_START = action('BOOKMARK_DRAG_START');
 export const BOOKMARK_DRAG_HOVER = action('BOOKMARK_DRAG_HOVER');
 export const BOOKMARK_DRAG_DROP = action('BOOKMARK_DRAG_DROP');
 export const BOOKMARK_DRAG_CANCEL = action('BOOKMARK_DRAG_CANCEL');
+export const BOOKMARK_EDIT = action('BOOKMARK_EDIT');
+export const BOOKMARK_EDIT_DONE = action('BOOKMARK_EDIT_DONE');
 
 /**
  * Pin a state to navigate successors

--- a/packages/dag-history-component/src/state/reducers/bookmarkEdit.ts
+++ b/packages/dag-history-component/src/state/reducers/bookmarkEdit.ts
@@ -1,0 +1,23 @@
+import * as Types from '../actions/types';
+import {
+  IConfiguration, // eslint-disable-line no-unused-vars
+} from '@essex/redux-dag-history/lib/interfaces';
+import isHistoryAction from './isHistoryAction';
+
+export const INITIAL_STATE = {
+  editIndex: undefined,
+};
+
+export default function makeReducer(config: IConfiguration<any>) {
+  return function reduce(state = INITIAL_STATE, action) {
+    if (action.type === Types.BOOKMARK_EDIT) {
+      return { editIndex: action.payload };
+    } else if (
+      action.type === Types.BOOKMARK_EDIT_DONE ||
+      !isHistoryAction(action) && config.actionFilter(action.type)
+    ) {
+      return INITIAL_STATE;
+    }
+    return state;
+  };
+}

--- a/packages/dag-history-component/src/state/reducers/bookmarkEdit.ts
+++ b/packages/dag-history-component/src/state/reducers/bookmarkEdit.ts
@@ -11,11 +11,16 @@ export const INITIAL_STATE = {
 export default function makeReducer(config: IConfiguration<any>) {
   return function reduce(state = INITIAL_STATE, action) {
     if (action.type === Types.BOOKMARK_EDIT) {
+      // Edit a bookmark
       return { editIndex: action.payload };
+    } else if (action.type === Types.MOVE_BOOKMARK && action.payload.from === state.editIndex) {
+      // If the user is moving the currently edited bookmark, update the editIndex
+      return { editIndex: action.payload.to };
     } else if (
       action.type === Types.BOOKMARK_EDIT_DONE ||
       !isHistoryAction(action) && config.actionFilter(action.type)
     ) {
+      // Clear the edit state
       return INITIAL_STATE;
     }
     return state;

--- a/packages/dag-history-component/src/state/reducers/bookmarks.ts
+++ b/packages/dag-history-component/src/state/reducers/bookmarks.ts
@@ -47,8 +47,7 @@ export default function reduce(state = INITIAL_STATE, action) {
       const moved = bookmarks[from];
       if (from !== to) {
         bookmarks.splice(from, 1);
-        // adjust the insertion index
-        bookmarks.splice(from < to ? to - 1 : to, 0, moved);
+        bookmarks.splice(to, 0, moved);
       }
       return bookmarks;
     }

--- a/packages/dag-history-component/src/state/reducers/bookmarks.ts
+++ b/packages/dag-history-component/src/state/reducers/bookmarks.ts
@@ -47,7 +47,8 @@ export default function reduce(state = INITIAL_STATE, action) {
       const moved = bookmarks[from];
       if (from !== to) {
         bookmarks.splice(from, 1);
-        bookmarks.splice(to, 0, moved);
+        // adjust the insertion index
+        bookmarks.splice(from < to ? to - 1 : to, 0, moved);
       }
       return bookmarks;
     }

--- a/packages/dag-history-component/src/state/reducers/index.ts
+++ b/packages/dag-history-component/src/state/reducers/index.ts
@@ -4,10 +4,13 @@ import views from './views';
 import playback from './playback';
 import bookmarks from './bookmarks';
 import pinnedState from './pinnedState';
+import bookmarkEdit from './bookmarkEdit';
+
 import { IComponentConfiguration } from '../interfaces'; // eslint-disable-line no-unused-vars
 
 export default function createReducer<T>(config: IComponentConfiguration<T>) {
   return redux.combineReducers({
+    bookmarkEdit: bookmarkEdit(config),
     dragDrop: dragDrop(config),
     views: views(config),
     playback: playback(config),

--- a/packages/dag-history-component/stories/components/Bookmark/index.tsx
+++ b/packages/dag-history-component/stories/components/Bookmark/index.tsx
@@ -5,6 +5,8 @@ import Bookmark from '../../../src/components/Bookmark/Bookmark';
 storiesOf('Bookmark', module)
 .add('Inactive', () => (
   <Bookmark
+    index={0}
+    commitPathLength={1}
     name="Some Bookmark Name"
     annotation="Some Bookmark Annotation Text. Derp Depr Derp Derp"
     onClick={action('click')}
@@ -12,6 +14,8 @@ storiesOf('Bookmark', module)
 ))
 .add('Active', () => (
   <Bookmark
+    index={1}
+    commitPathLength={1}
     name="Some Bookmark Name"
     annotation="Some Bookmark Annotation Text. Derp Depr Derp Derp"
     onClick={action('click')}

--- a/packages/dag-history-component/test/state/actions/creators.spec.ts
+++ b/packages/dag-history-component/test/state/actions/creators.spec.ts
@@ -44,7 +44,7 @@ describe('The Action Creators Module', () => {
     it('will emit bookmark selection and jump events', () => {
       const bookmarkIndex = 5;
       const depth = 7;
-      const state = 10;
+      const state = '10';
 
       const dispatch = sinon.spy();
       ActionCreators.selectBookmarkDepth({ bookmarkIndex, depth, state })(dispatch);
@@ -63,7 +63,7 @@ describe('The Action Creators Module', () => {
   describe('the selectBookmark action', () => {
     it('will emit bookmark selection and jump events', () => {
       const bookmarkIndex = 3;
-      const state = 7;
+      const state = '7';
       const dispatch = sinon.spy();
       ActionCreators.selectBookmark(bookmarkIndex, state)(dispatch);
 

--- a/packages/dag-history-component/test/state/reducers/bookmarks.spec.ts
+++ b/packages/dag-history-component/test/state/reducers/bookmarks.spec.ts
@@ -4,7 +4,7 @@ import {
   addBookmark,
   removeBookmark,
   renameBookmark,
-  changeBookmark,
+  doChangeBookmark,
   moveBookmark,
 } from '../../../src/state/actions/creators';
 
@@ -54,25 +54,31 @@ describe('The bookmarks reducer', () => {
 
   it('can change a bookmark', () => {
     let state;
-    state = reduce(state, addBookmark({ stateId: 1, name: 'state1' }));
-    state = reduce(state, addBookmark({ stateId: 2, name: 'state2' }));
-    state = reduce(state, addBookmark({ stateId: 3, name: 'state3' }));
+    state = reduce(state, addBookmark({ stateId: '1', name: 'state1' }));
+    state = reduce(state, addBookmark({ stateId: '2', name: 'state2' }));
+    state = reduce(state, addBookmark({ stateId: '3', name: 'state3' }));
 
-    state = reduce(state, changeBookmark({ stateId: 2, name: 'newName', data: { x: 1 } }));
+    state = reduce(state, doChangeBookmark({ stateId: '2', name: 'newName', data: { x: 1 } }));
     expect(state[1].name).to.equal('newName');
     expect(state[1].data).to.deep.equal({ x: 1 });
   });
 
   it('can move a bookmark', () => {
     let state;
-    state = reduce(state, addBookmark({ stateId: 1, name: 'state1' }));
-    state = reduce(state, addBookmark({ stateId: 2, name: 'state2' }));
-    state = reduce(state, addBookmark({ stateId: 3, name: 'state3' }));
+    state = reduce(state, addBookmark({ stateId: '1', name: 'state1' }));
+    state = reduce(state, addBookmark({ stateId: '2', name: 'state2' }));
+    state = reduce(state, addBookmark({ stateId: '3', name: 'state3' }));
 
     state = reduce(state, moveBookmark({ from: 0, to: 2 }));
-    expect(fan(state)).to.deep.equal([2, 3, 1]);
+    expect(fan(state)).to.deep.equal(['2', '3', '1']);
+
+    state = reduce(state, moveBookmark({ from: 0, to: 1 }));
+    expect(fan(state)).to.deep.equal(['3', '2', '1']);
+
+    state = reduce(state, moveBookmark({ from: 2, to: 1 }));
+    expect(fan(state)).to.deep.equal(['3', '1', '2']);
 
     state = reduce(state, moveBookmark({ from: 2, to: 0 }));
-    expect(fan(state)).to.deep.equal([1, 2, 3]);
+    expect(fan(state)).to.deep.equal(['2', '3', '1']);
   });
 });

--- a/packages/redux-dag-history/src/DagGraph.ts
+++ b/packages/redux-dag-history/src/DagGraph.ts
@@ -298,11 +298,11 @@ export default class DagGraph<T> {
    * @param commit The state id to get the physical state of
    */
   public getState(commit: StateId): T {
-    return this.graph.getIn(['states', `${commit}`, 'state']);
+    return this.graph.getIn(['physicalStates', `${commit}`]);
   }
 
   /**
-   * Inserts a nem tstate
+   * Inserts a new state
    * @param commit The new state id
    * @param parent The parent state id
    * @param state The physical state
@@ -310,12 +310,13 @@ export default class DagGraph<T> {
    */
   public insertState(commit: StateId, parent: StateId, state: T, name: string) {
     log('Inserting new commit', commit);
-    const newState = ImmutableFromJS({ name, parent }).set('state', state);
     if (this.graph.getIn(['states', `${commit}`])) {
       log('Commit %s is already present', this.getState(commit));
     }
 
-    this.graph = this.graph.setIn(['states', `${commit}`], newState);
+    this.graph = this.graph
+      .setIn(['states', `${commit}`], ImmutableFromJS({name, parent}))
+      .setIn(['physicalStates', `${commit}`], state);
     return this;
   }
 
@@ -400,7 +401,7 @@ export default class DagGraph<T> {
    * @param state The new state
    */
   public replaceState(commit: StateId, state: T) {
-    this.graph = this.graph.setIn(['states', `${commit}`, 'state'], state);
+    this.graph = this.graph.setIn(['physicalStates', `${commit}`], state);
     return this;
   }
 
@@ -538,7 +539,9 @@ export default class DagGraph<T> {
   private remove(commit: StateId) {
     // TODO: we should remove this from the branch list and other metadata as well.
     // This will be how we keep the DAG pruned to a fixed size.
-    this.graph = this.graph.deleteIn(['states', `${commit}`]);
+    this.graph = this.graph
+      .deleteIn(['states', `${commit}`])
+      .deleteIn(['physicalStates', `${commit}`]);
   }
 
   /**

--- a/packages/redux-dag-history/src/DagHistory/createHistory.ts
+++ b/packages/redux-dag-history/src/DagHistory/createHistory.ts
@@ -23,7 +23,6 @@ export default function createHistory<T>(
 
   // We may need to insert the initial hash into the state data, so construct it here
   const initialStateData = {
-    state: initialState,
     name: initialStateName,
     branch: 1,
   };
@@ -81,10 +80,17 @@ export default function createHistory<T>(
       },
 
       /**
-       * A map of state-ids to state data
+       * A map of state-ids to state metadata
        */
       states: {
         [stateId]: initialStateData,
+      },
+
+      /**
+       * A map of state ids to physical states
+       */
+      physicalStates: {
+        [stateId]: initialState,
       },
     },
   });

--- a/packages/redux-dag-history/src/DagHistory/load.ts
+++ b/packages/redux-dag-history/src/DagHistory/load.ts
@@ -1,9 +1,20 @@
-import { fromJS } from 'immutable';
+import { fromJS, Map } from 'immutable';
 import { IDagHistory } from '../interfaces';
+import DagGraph from '../DagGraph';
 
 export default function load<T>(history: any): IDagHistory<T> {
+  // Immutabilize the history graph, sans the physical states that are present
+  const copiedGraph = {...history.graph};
+  delete copiedGraph.physicalStates;
+  let graph = fromJS(copiedGraph) as Map<string, any>;
+
+  // Insert the states into the dag graph, we do this dance so we don't accidentally turn raw JS to immutable
+  Object.keys(history.graph.physicalStates).forEach(state => {
+    graph = graph.setIn(['physicalStates', `${state}`], history.graph.physicalStates[state]);
+  });
+
   return {
     ...history,
-    graph: fromJS(history.graph),
+    graph,
   };
 }


### PR DESCRIPTION
I need to be able to instrument the full state of the dag-history-component, so this commit removes setState() invocations, and instead models the 'currently edited bookmark' index in the component reducer. 

Additionally, I was seeing some issues when bookmarking the initial state. When the graph is initially loaded, it's turned into an ImmutableJS instance, which included the initial state being passed in. This change prevents the physical states that are initially present on load from being 'Immutabilized'.

