### PR TITLE
Clean up HistoryContainer props

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,5 +101,9 @@
       "^.+\\.(ts|tsx)$": "<rootDir>/scripts/preprocessor.js"
     },
     "testRegex": ".*/packages/.*/test/.*/.*\\.spec\\.(ts|tsx|js)$"
+  },
+  "devDependencies": {
+    "@types/redux-logger": "^2.6.34",
+    "redux-logger": "^2.8.2"
   }
 }

--- a/packages/dag-history-component/example/components/HistoryPresenter.tsx
+++ b/packages/dag-history-component/example/components/HistoryPresenter.tsx
@@ -5,7 +5,11 @@ import '../../src/daghistory.scss';
 import createHistoryContainer from '../../src/components/createHistoryContainer';
 import { get } from 'lodash';
 
-const HistoryContainer = createHistoryContainer(state => state.app, state => state.component);
+const HistoryContainer = createHistoryContainer(
+  state => state.app,
+  state => state.component,
+  state => get(state, 'metadata.source')
+);
 
 const { PropTypes } = React;
 
@@ -15,7 +19,6 @@ const HistoryPresenter: React.StatelessComponent<void> = (props) => {
       <HistoryContainer
         bookmarksEnabled
         controlBarEnabled
-        getSourceFromState={state => get(state, 'metadata.source')}
         controlBar={{
           onSaveHistory: save,
           onLoadHistory: load,

--- a/packages/dag-history-component/example/components/HistoryPresenter.tsx
+++ b/packages/dag-history-component/example/components/HistoryPresenter.tsx
@@ -8,7 +8,7 @@ import { get } from 'lodash';
 const HistoryContainer = createHistoryContainer(
   state => state.app,
   state => state.component,
-  state => get(state, 'metadata.source')
+  state => get(state, 'metadata.source'),
 );
 
 const { PropTypes } = React;
@@ -18,7 +18,6 @@ const HistoryPresenter: React.StatelessComponent<void> = (props) => {
     <div className="history-viz-container">
       <HistoryContainer
         bookmarksEnabled
-        controlBarEnabled
         controlBar={{
           onSaveHistory: save,
           onLoadHistory: load,

--- a/packages/dag-history-component/src/components/Bookmark/EditBookmark.tsx
+++ b/packages/dag-history-component/src/components/Bookmark/EditBookmark.tsx
@@ -98,7 +98,6 @@ export default class EditBookmark extends React.Component<IEditBookmarkProps, IE
       onSelectBookmarkDepth,
       shortestCommitPath,
     } = this.props;
-
     if (onSelectBookmarkDepth) {
       const state = shortestCommitPath[depth || shortestCommitPath.length - 1];
       onSelectBookmarkDepth({ bookmarkIndex, depth, state });
@@ -148,7 +147,6 @@ export default class EditBookmark extends React.Component<IEditBookmarkProps, IE
             rows={5}
             placeholder="Enter caption for presentation"
             defaultValue={annotation}
-            onFocus={() => onClick()}
             onBlur={() => this.onDoneEditing()}
           />
           <div>

--- a/packages/dag-history-component/src/components/History/index.tsx
+++ b/packages/dag-history-component/src/components/History/index.tsx
@@ -90,7 +90,6 @@ export default class History extends React.Component<IHistoryProps, {}> {
      * Bookbark Configuration Properties
      */
     bookmarksEnabled: PropTypes.bool,
-    controlBarEnabled: PropTypes.bool,
   };
 
   shouldComponentUpdate(nextProps) {
@@ -200,13 +199,13 @@ export default class History extends React.Component<IHistoryProps, {}> {
       mainView,
       onSelectMainView,
       bookmarksEnabled,
-      controlBarEnabled,
       isPlayingBack,
+      controlBar,
     } = this.props;
     return isPlayingBack ? this.renderPlayback() : (
       <HistoryTabs
         bookmarksEnabled={bookmarksEnabled}
-        controlBarEnabled={controlBarEnabled}
+        controlBarEnabled={!!controlBar}
         selectedTab={mainView}
         onTabSelect={onSelectMainView}
         historyView={<HistoryView {...this.props} />}

--- a/packages/dag-history-component/src/components/History/interfaces.ts
+++ b/packages/dag-history-component/src/components/History/interfaces.ts
@@ -18,10 +18,10 @@ export interface IHistoryContainerSharedProps {
   getSourceFromState: Function;
   bookmarksEnabled?: boolean;
 
-  controlBarEnabled?: boolean;
-
   /**
    * ControlBar Configuration Properties
+   *
+   * If the controlBar property is undefined, the control bar will be disabled.
    */
   controlBar?: {
     /**

--- a/packages/dag-history-component/src/components/createHistoryContainer.tsx
+++ b/packages/dag-history-component/src/components/createHistoryContainer.tsx
@@ -27,7 +27,6 @@ export interface IHistoryContainerDispatchProps extends IHistoryDispatchProps {
 
 export interface IHistoryContainerOwnProps {
   bookmarksEnabled?: boolean;
-  controlBarEnabled?: boolean;
 
   /**
    * ControlBar Configuration Properties

--- a/packages/dag-history-component/src/components/createHistoryContainer.tsx
+++ b/packages/dag-history-component/src/components/createHistoryContainer.tsx
@@ -19,6 +19,7 @@ export interface IHistoryContainerStateProps {
   selectedBookmark?: number;
   selectedBookmarkDepth?: number;
   bookmarks?: IBookmark[];
+  getSourceFromState: Function;
 }
 
 export interface IHistoryContainerDispatchProps extends IHistoryDispatchProps {
@@ -47,8 +48,6 @@ export interface IHistoryContainerOwnProps {
      */
     onConfirmClear: Function;
   };
-
-  getSourceFromState: Function;
 }
 
 export interface IHistoryContainerProps extends
@@ -64,11 +63,13 @@ HistoryContainer.propTypes = {
   ...HistoryComponent.propTypes,
 };
 
-export default function createHistoryContainer(getMiddlewareState: Function, getComponentState: Function) {
+export default function createHistoryContainer(getMiddlewareState: Function, getComponentState: Function, getSourceFromState: Function) {
   const mapStateToProps = (state) => {
     const middleware = getMiddlewareState(state);
     const component = getComponentState(state);
     return {
+      getSourceFromState,
+
       // State from the redux-dag-history middleware
       history: middleware,
       pinnedStateId: component.pinnedState.id,

--- a/packages/dag-history-component/stories/components/History/index.tsx
+++ b/packages/dag-history-component/stories/components/History/index.tsx
@@ -1,0 +1,114 @@
+import * as React from 'react';
+import * as redux from 'redux';
+import { Provider } from 'react-redux';
+import thunk from 'redux-thunk';
+import * as createLogger from 'redux-logger';
+import HTML5Backend from 'react-dnd-html5-backend';
+import { storiesOf, action } from '@kadira/storybook';
+import { get } from 'lodash';
+import createHistoryContainer from '../../../src/components/createHistoryContainer';
+import { fromJS } from 'immutable';
+
+const DragDropContextProvider = require('react-dnd/lib/DragDropContextProvider').default;
+
+const Container = createHistoryContainer(
+  state => state.app,
+  state => state.component,
+  state => get(state, 'metadata.source'),
+);
+
+function createStore(state) {
+  // A simple static reducer
+  const reducer = () => state;
+
+  // If the redux devtools are available, wire into them
+  const composeEnhancers = window['__REDUX_DEVTOOLS_EXTENSION_COMPOSE__'] || redux.compose;
+  const logger = createLogger();
+
+  const store: redux.Store<any> = composeEnhancers(
+    redux.applyMiddleware(
+      thunk,
+      logger,
+    ),
+  )(redux.createStore)(reducer);
+  return store;
+}
+
+storiesOf('History Injection', module)
+  .add('On Bookmarks view with ', () => {
+    const store = createStore({
+      app: {
+        current: {},
+        graph: fromJS({
+          'current': {
+            'state': '32',
+            'branch': '0',
+          },
+          'branches': {
+            '0': {
+              'latest': '34',
+              'name': 'Branch 0',
+              'first': '1',
+              'committed': '34',
+            },
+          },
+          'states': {
+            '27': {
+              'id': '27',
+              'name': 'Initial State',
+              'branch': '0',
+            },
+            '28': {
+              'id': '28',
+              'name': 'Add Empty Visual Container',
+              'branch': '0',
+              'parent': '27',
+            },
+            '29': { 'id': '29', 'name': 'Add Field', 'branch': '0', 'parent': '28' },
+            '30': { 'id': '30', 'name': 'Update Dimensions', 'branch': '0', 'parent': '29' },
+            '31': { 'id': '31', 'name': 'Update Dimensions', 'branch': '0', 'parent': '30' },
+            '32': { 'id': '32', 'name': 'Execute Action', 'branch': '0', 'parent': '31' },
+            '33': { 'id': '33', 'name': 'Execute Action', 'branch': '0', 'parent': '32' },
+            '34': { 'id': '34', 'name': 'Execute Action', 'branch': '0', 'parent': '33' },
+          },
+          'physicalStates': {
+            '27': {},
+            '28': {},
+            '29': {},
+            '30': {},
+            '31': {},
+            '32': {},
+            '33': {},
+            '34': {},
+          },
+          'lastStateId': '34',
+          'lastBranchId': '1',
+          'stateHash': {},
+          'chronologicalStates': ['27', '28', '29', '30', '31', '32', '33', '34'],
+        }),
+      },
+      component: {
+        'bookmarkEdit': { 'editIndex': 6 },
+        'dragDrop': {},
+        'views': { 'mainView': 'storyboarding', 'historyType': 'branched', 'branchContainerExpanded': false },
+        'playback': { 'isPlayingBack': false, 'bookmark': 6, depth: 1 },
+        'pinnedState': { 'id': '21' },
+        'bookmarks': [
+          { 'name': 'Execute Action', 'stateId': '25', 'data': {} },
+          { 'name': 'Execute Action', 'stateId': '21', 'data': {} },
+          { 'name': 'Initial State', 'stateId': '19', 'data': {} },
+          { 'name': 'Execute Action', 'stateId': '23', 'data': {} },
+          { 'name': 'Execute Action', 'stateId': '34', 'data': {} },
+          { 'name': 'Execute Action', 'stateId': '33', 'data': {} },
+          { 'name': 'Execute Action', 'stateId': '32', 'data': {} },
+        ]
+      },
+    });
+    return (
+      <Provider store={store}>
+        <DragDropContextProvider backend={HTML5Backend}>
+          <Container bookmarksEnabled />
+        </DragDropContextProvider>
+      </Provider>
+    );
+  });

--- a/packages/dag-history-component/stories/index.ts
+++ b/packages/dag-history-component/stories/index.ts
@@ -5,3 +5,4 @@ import './components/BranchProfile';
 import './components/Continuation';
 import './components/State';
 import './components/DiscoveryTrail';
+import './components/History';

--- a/yarn.lock
+++ b/yarn.lock
@@ -206,6 +206,12 @@
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@types/redux-actions/-/redux-actions-1.2.2.tgz#2f90cd3ecde5c37a47a90caf4df1ffd34e2e29dd"
 
+"@types/redux-logger@^2.6.34":
+  version "2.6.34"
+  resolved "https://registry.yarnpkg.com/@types/redux-logger/-/redux-logger-2.6.34.tgz#4f0201ce75cf7e35f3ea22cbeb71f20568e93262"
+  dependencies:
+    redux "^3.6.0"
+
 "@types/redux-thunk@^2.1.32":
   version "2.1.32"
   resolved "https://registry.yarnpkg.com/@types/redux-thunk/-/redux-thunk-2.1.32.tgz#27fac368ced9ea170bf15e5fa4a21d9201f73102"
@@ -2030,6 +2036,10 @@ debug@~2.2.0:
 decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
+
+deep-diff@0.3.4:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/deep-diff/-/deep-diff-0.3.4.tgz#aac5c39952236abe5f037a2349060ba01b00ae48"
 
 deep-eql@^0.1.3:
   version "0.1.3"
@@ -5526,6 +5536,12 @@ redux-actions@^1.2.1:
     invariant "^2.2.1"
     lodash "^4.13.1"
     reduce-reducers "^0.1.0"
+
+redux-logger@^2.8.2:
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/redux-logger/-/redux-logger-2.8.2.tgz#52140a89afa1c1d25312cc17649c116650bf7fca"
+  dependencies:
+    deep-diff "0.3.4"
 
 redux-thunk@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
When the HistoryContainer is used in JSX, one of the necessary props is the `getSourceFromState` function, this has been moved to the `createHistoryContainer` function, as it seems more appropriate there. 

Additionally, the `controlBarEnabled` boolean prop has been removed. If the `controlBar`prop is present, then it's implicit that the control bar should be enabled, and vice-versa.